### PR TITLE
Fix autowiring for the Registry service

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,7 +23,7 @@ class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->scalarNode('class')->isRequired()->cannotBeEmpty()->end()
-                        ->scalarNode('storage_class')->defaultValue(Storage::class)->isRequired()->cannotBeEmpty()->end()
+                        ->scalarNode('storage_class')->defaultValue(Storage::class)->cannotBeEmpty()->end()
                         ->scalarNode('collection')->isRequired()->cannotBeEmpty()->end()
                         ->scalarNode('database')->defaultValue(null)->end()
                         ->scalarNode('hydrator')->defaultValue(false)->end()

--- a/DependencyInjection/YadmExtension.php
+++ b/DependencyInjection/YadmExtension.php
@@ -84,5 +84,9 @@ class YadmExtension extends Extension
             ->addArgument($storages)
             ->addArgument($repositories)
         ;
+
+        $container->addAliases([
+            Registry::class => 'yadm'
+        ]);
     }
 }


### PR DESCRIPTION
Hello Max,

Thank you for your work.
I propose this PR to fix autowiring for the Registry service.

For exemple :

```php

    /**
     * @Route("test")
     */
    public function index(Request $request, Registry $registry)
    {
        $storage = $registry->getStorage(Product::class);
        // ...
    }

```

I also fixed a little bug in the Configuration class. `isRequired` prevents to use the default value.


